### PR TITLE
Fixing a clearing bug for WordPress 4.5+

### DIFF
--- a/menu-image.php
+++ b/menu-image.php
@@ -666,7 +666,7 @@ class Menu_Image_Walker_Nav_Menu_Edit extends Walker_Nav_Menu_Edit {
 				</dt>
 			</dl>
 
-			<div class="menu-item-settings" id="menu-item-settings-<?php echo $item_id; ?>">
+			<div class="menu-item-settings wp-clearfix" id="menu-item-settings-<?php echo $item_id; ?>">
 				<?php if( 'custom' == $item->type ) : ?>
 					<p class="field-url description description-wide">
 						<label for="edit-menu-item-url-<?php echo $item_id; ?>">


### PR DESCRIPTION
As mentioned in the support channel: https://wordpress.org/support/topic/fix-the-settings-container-for-wp-45